### PR TITLE
moving server configuration to external yaml file

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -1,0 +1,21 @@
+---
+- hostname: dev-sandbox-publisher.local.dev.wso2.org
+  product_name: wso2am
+  product_version: 1.9.1
+  product_profile: default
+  environment: dev
+  vm_type: vagrant
+  box: ubuntu/trusty64
+  ip: 192.168.100.10
+  ram: 2048
+  cpu: 1
+- hostname: dev-sandbox-store.local.dev.wso2.org
+  product_name: wso2am
+  product_version: 1.9.1
+  product_profile: default
+  environment: dev
+  vm_type: vagrant
+  box: ubuntu/trusty64
+  ip: 192.168.100.20
+  ram: 2048
+  cpu: 1


### PR DESCRIPTION
This change allows you to run multiple products without having to modify the vagrant file. With this modification, we can define any number of servers in servers.yaml and process them using hostname (vagrant 'command' hostname)
